### PR TITLE
More verbose error

### DIFF
--- a/tester/unittester/unittester.go
+++ b/tester/unittester/unittester.go
@@ -37,9 +37,9 @@ func ErrorIn(ut testerconfig.UnitTest, r []byte, err error) *UnitTesterError {
 
 func (e *UnitTesterError) Error() string {
 	if e.Result == nil {
-		return fmt.Sprintf("in test : '%s:%s'\nIn: %s\nOut: %s\nCtOut : %s \nErr : %s", e.Ut.Action, e.Ut.Url, e.Ut.InName, e.Ut.OutName, e.Ut.CtOut, e.Err.Error())
+		return fmt.Sprintf("in test : '%s:%s'\nIn: %s\nOut: %s\nCtOut: %s\nStatus: %d\nHeaders: %s\nErr: %s", e.Ut.Action, e.Ut.Url, e.Ut.InName, e.Ut.OutName, e.Ut.CtOut, e.Ut.Status, e.Ut.Headers, e.Err.Error())
 	}
-	return fmt.Sprintf("in test : '%s:%s'\nIn: %s\nOut: %s\nCtOut : %s \nErr : %s \ngot : \n%s", e.Ut.Action, e.Ut.Url, e.Ut.InName, e.Ut.OutName, e.Ut.CtOut, e.Err.Error(), e.Result)
+	return fmt.Sprintf("in test : '%s:%s'\nIn: %s\nOut: %s\nCtOut: %s\nStatus: %d\nHeaders: %s\nErr: %s\ngot : \n%s", e.Ut.Action, e.Ut.Url, e.Ut.InName, e.Ut.OutName, e.Ut.CtOut, e.Ut.Status, e.Ut.Headers, e.Err.Error(), e.Result)
 }
 func (e *UnitTesterError) Unwrap() error { return e.Err }
 
@@ -112,11 +112,15 @@ func (t *UnitTester) runApi(ut testerconfig.UnitTest) error {
 		if r.Body != nil {
 			bodyBytes, _ = ioutil.ReadAll(r.Body)
 		}
-		return ErrorIn(ut, nil, fmt.Errorf("%w: got %d expected %d \nRsp : \n%s", ErrWrongStatus, r.StatusCode, ut.Status, string(bodyBytes)))
+		return ErrorIn(ut, nil, fmt.Errorf("%w: got %d expected %d.\nRsp: \n%s", ErrWrongStatus, r.StatusCode, ut.Status, string(bodyBytes)))
 	}
 
 	if ut.CtOut != "" && !strings.HasPrefix(r.ContentType, ut.CtOut) {
-		return ErrorIn(ut, nil, fmt.Errorf("%w: %s expected %s.", ErrWrongContentType, r.ContentType, ut.CtOut))
+		var bodyBytes []byte
+		if r.Body != nil {
+			bodyBytes, _ = ioutil.ReadAll(r.Body)
+		}
+		return ErrorIn(ut, nil, fmt.Errorf("%w: %s expected %s.\nRsp: \n%s", ErrWrongContentType, r.ContentType, ut.CtOut, string(bodyBytes)))
 	}
 
 	if ut.Out != nil {


### PR DESCRIPTION
Added 
 - request header
 - expected status
 - body response on wrong content type error
 - indent json response

```
 Error while running test: In test 1 : in test : 'POST:/api/studies/#id#/authorization'
        In: postAcceptedAuthorization
        Out: 
        CtOut: 
        Status: 202
        Headers: map[X-Auth-Token:#token_trader#]
        Err: Wrong status found: got 201 expected 202.
        Rsp: 
        {
        	"id": "bd0b89a9-c8a1-4152-804c-b2e358c668dd",
        	"metadata": "posted_metadata",
        	"identity": {
        		"civility": "Mme",
        		"lastname": "posted_first_name_1",
        		"firstname": "posted_last_name_1",
        		"phone": "posted_phone_1",
        		"email": "new_applicant@everycheck.fr"
        	},
        	"experiences": [],
        	"stamps": [],
        	"category": {
        		"value": 1,
        		"name": "Created"
        	},
        	"authorization": {
        		"accepted": true,
        		"date": "2022-09-27T14:04:12+0000",
        		"ip": "127.0.0.1",
        		"useragent": "Go-http-client\/1.1",
        		"font": "Loveletter"
        	},
        	"sender": "posted_study@everycheck.fr",
        	"_links": {
        		"self": {
        			"href": "\/api\/studies\/bd0b89a9-c8a1-4152-804c-b2e358c668dd"
        		}
        	}
        }

```